### PR TITLE
 set brother_ql_web.py encoding to UTF-8

### DIFF
--- a/brother_ql_web.py
+++ b/brother_ql_web.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 """
 This is a web service to print labels on Brother QL label printers.

--- a/brother_ql_web.py
+++ b/brother_ql_web.py
@@ -18,6 +18,7 @@ from brother_ql.backends import backend_factory, guess_backend
 
 from font_helpers import get_fonts
 
+logging.basicConfig(filename='printhistory.log',level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 DEBUG = False
@@ -214,6 +215,9 @@ def print_text():
             logger.warning('Exception happened: %s', e)
             return return_dict
 
+    remote_hostinfo = socket.gethostbyaddr("request['REMOTE_ADDR']")
+    logger.info('IP: %s Hostname: %s Printing: %s', request['REMOTE_ADDR'], remote_hostinfo[0], context['text'])
+
     return_dict['success'] = True
     if DEBUG: return_dict['data'] = str(qlr.data)
     return return_dict
@@ -269,7 +273,7 @@ def main():
         DEFAULT_FONT = {'family': family, 'style': style}
         sys.stderr.write('The default font is now set to: {family} ({style})\n'.format(**DEFAULT_FONT))
 
-    run(host='', port=args.port, debug=DEBUG)
+    run(host='', port=args.port, debug=DEBUG, quiet=not DEBUG)
 
 if __name__ == "__main__":
     main()

--- a/brother_ql_web.py
+++ b/brother_ql_web.py
@@ -215,7 +215,7 @@ def print_text():
             logger.warning('Exception happened: %s', e)
             return return_dict
 
-    remote_hostinfo = socket.gethostbyaddr("request['REMOTE_ADDR']")
+    remote_hostinfo = socket.gethostbyaddr(request['REMOTE_ADDR'])
     logger.info('IP: %s Hostname: %s Printing: %s', request['REMOTE_ADDR'], remote_hostinfo[0], context['text'])
 
     return_dict['success'] = True


### PR DESCRIPTION
Hi Pklaus,

Have a look at https://github.com/pklaus/brother_ql_web/commit/ce4f028def0bd5846d98a3dbcea0743809e811f1
This way I can confirm it is working on Fedora Server 28 with QL-1060N via tcp.

I am quite new to Github so if this is not te correct way to give this info to you, please let me know.

Kind regards,

Jeroen