### PR TITLE
added explicit encoding to open call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## brother\_ql\_web
+## Web label maker
 
-This is a web service to print labels on Brother QL label printers.
+Forked [this](https://github.com/pklaus/brother_ql_web) project and replaced the brother library by PYCUPS. Need some work to actually properly support CUPS printers. It currently only prints the images that are created by the script. 
 
 You need Python 3 for this software to work.
 
@@ -17,9 +17,9 @@ Otherwise, follow the instructions below.
 
 Get the code:
 
-    git clone https://github.com/pklaus/brother_ql_web.git
+    git clone https://github.com/ReinierH/brother_ql_web.git
 
-or download [the ZIP file](https://github.com/pklaus/brother_ql_web/archive/master.zip) and unpack it.
+or download [the ZIP file](https://github.com/ReinierH/brother_ql_web/archive/master.zip) and unpack it.
 
 Install the requirements:
 

--- a/brother_ql_web.py
+++ b/brother_ql_web.py
@@ -22,10 +22,10 @@ logger = logging.getLogger(__name__)
 LABEL_SIZES = [ (name, label_type_specs[name]['name']) for name in label_sizes]
 
 try:
-    with open('config.json') as fh:
+    with open('config.json', encoding='utf-8') as fh:
         CONFIG = json.load(fh)
 except FileNotFoundError as e:
-    with open('config.example.json') as fh:
+    with open('config.example.json', encoding='utf-8') as fh:
         CONFIG = json.load(fh)
 
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,16 +1,16 @@
 {
+  "CUPS_HOST": "localhost",
   "SERVER": {
-    "PORT": 8013,
+    "PORT": 8000,
     "HOST": "",
     "LOGLEVEL": "WARNING",
     "ADDITIONAL_FONT_FOLDER": false
   },
   "PRINTER": {
-    "MODEL": "QL-500",
-    "PRINTER": "file:///dev/usb/lp1"
+    "NAME": "DYMO_LabelWriter_450",
   },
   "LABEL": {
-    "DEFAULT_SIZE": "62",
+    "DEFAULT_SIZE": "39x90",
     "DEFAULT_ORIENTATION": "standard",
     "DEFAULT_FONT_SIZE": 70,
     "DEFAULT_FONTS": [
@@ -21,7 +21,7 @@
   },
   "WEBSITE": {
     "HTML_TITLE": "Label Designer",
-    "PAGE_TITLE": "Brother QL Label Designer",
+    "PAGE_TITLE": "Label Designer",
     "PAGE_HEADLINE": "Design your label and print it…"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-brother_ql
+pycups
 bottle
 jinja2


### PR DESCRIPTION
Ran into an error while running it:

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 677: ordinal not in range(128)

It tried to decode the json file in ascii. Adding an explicit encoding type to the open call fixed it.