### PR TITLE
Fixed a bug where certain fonts caused the script to crash

### DIFF
--- a/font_helpers.py
+++ b/font_helpers.py
@@ -20,8 +20,13 @@ def get_fonts(folder=None):
         if not line: continue
         if 'otf' not in line and 'ttf' not in line: continue
         parts = line.split(':')
+
+        logger.debug(len(parts))
+        if len(parts) < 3: continue
+
         path = parts[0]
         families = parts[1].strip().split(',')
+
         styles = parts[2].split('=')[1].split(',')
         if len(families) == 1 and len(styles) > 1:
             families = [families[0]] * len(styles)


### PR DESCRIPTION
Simple check to stop the below from happening - seems to be certain fonts (none-ASCII names?) 

---
 
deprecation warning: brother_ql.devicedependent is deprecated and will be removed in a future release
Traceback (most recent call last):
  File "./brother_ql_web.py", line 296, in <module>
    main()
  File "./brother_ql_web.py", line 271, in main
    FONTS = get_fonts()
  File "/Users/justindm/Development/printer/brother_ql_web/font_helpers.py", line 25, in get_fonts
    styles = parts[2].split('=')[1].split(',')
IndexError: list index out of range

