### PR TITLE
set dpi_600 to True by default

### DIFF
--- a/brother_ql_web.py
+++ b/brother_ql_web.py
@@ -201,7 +201,8 @@ def print_text():
     red = False
     if 'red' in context['label_size']:
         red = True
-    create_label(qlr, im, context['label_size'], red=red, threshold=context['threshold'], cut=True, rotate=rotate)
+    create_label(qlr, im, context['label_size'], red=red, threshold=context['threshold'],
+                 cut=True, rotate=rotate, dpi_600=True)
 
     if not DEBUG:
         try:


### PR DESCRIPTION
The dpi_600 setting allows improved print quality at the expense of speed. However, it's still very fast and can significantly improve contrast on the prints, so I argue it should be enabled by default.
This could also be a checkbox somewhere in the UI later down the line.